### PR TITLE
Do not publish .babelrc to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# Do not publish .babelrc to npm since it can create problems with babel 5 in other projects
+.babelrc


### PR DESCRIPTION
Do not publish .babelrc to npm since it can create problems with babel 5 in other projects
