### PR TITLE
Bugfix: Unable to warn when message has format specifier `%o` (and possibly others)

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -68,7 +68,7 @@ function updateWarningMap(format, ...args): void {
   const argCount = (format.match(/%s/g) || []).length;
   const warning = [
     sprintf(format, ...args.slice(0, argCount)),
-    ...args.slice(argCount).map(stringifySafe),
+    ...args.slice(argCount).map(arg => stringifySafe(arg)),
   ].join(' ');
 
   const count = _warningMap.has(warning) ? _warningMap.get(warning) : 0;
@@ -84,4 +84,3 @@ export function isWarningIgnored(warning: string): boolean {
     )
   );
 }
-


### PR DESCRIPTION
This PR makes sure that only the argument is passed to `stringifySafe`. This prevents the index to be passed as the second argument (`replacer` in `stringifySafe`).

This fixes a bug that when you try to

``` javascript
console.warn('My object: %o', { test: 42 });
```

you get

```
TypeError: replacer.call is not a function
```
