### PR TITLE
Fix issue #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 
+/lib
+/yarn.lock

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ class YellowBox extends Component {
   }
 
   componentWillUnmount() {
-    if (this._listener) {
+    if (this._listener && typeof this._listener.remove === 'function') {
       this._listener.remove();
     }
   }


### PR DESCRIPTION
This is a fix for issue https://github.com/iamdustan/yellowbox-react/issues/6

Directly attaching a handler that calls setState will trigger this error. In my case using reactstrap’s `<Modal>` (https://reactstrap.github.io/components/modals/)

**Example**: 
```
<Modal toggle={this.toggleModal} />
``` 
where this.toggleModal() is calling* this.setState()

Issue #6 in Yellowbox hides the source of the problem, in this case directly calling the Modal.toggle handler when the component is mounting which causes a React.setStateLoopOfDoom error: 
**Screenshot:**
![image](https://user-images.githubusercontent.com/8559668/63228154-1ef9de80-c1a4-11e9-815f-b9a282b7dfac.png)

This patch makes sure that this._listener.remove() is a function before trying to call it, thereby allowing the real problem (set state loop) to show up.

... sorry bout the .gitignore and yarn.lock mess.

*Not sure it matters but I’m using immer to set state: https://github.com/immerjs/immer#reactsetstate-example